### PR TITLE
Add max file processing limit and Kerberos ticket checker

### DIFF
--- a/NGTLoopStep2.py
+++ b/NGTLoopStep2.py
@@ -504,7 +504,6 @@ class NGTLoopStep2:
         else:
             self.setOfExpressLS = self.setOfLSToProcess
 
-        # self.setOfExpressLS = self.setOfLSToProcess
         # Extract all LS numbers (as integers)
         str_paths = {"root://eoscms.cern.ch/" + str(p) for p in self.setOfExpressLS}
 

--- a/NGTLoopStep2.py
+++ b/NGTLoopStep2.py
@@ -497,14 +497,14 @@ class NGTLoopStep2:
             return
 
         # Thiago: new logic to avoid gigantic cmsRun jobs
-        # if(len(self.setOfLSToProcess) > self.maximumFilesPerJob):
-        #   as_a_list = sorted(self.setOfLSToProcess)
-        #   topTargets = as_a_list[0:self.maximumFilesPerJob]
-        #   self.setOfExpressLS = set(topTargets)
-        # else:
-        #   self.setOfExpressLS = self.setOfLSToProcess
+        if (len(self.setOfLSToProcess) > self.maximumFilesPerJob):
+            as_a_list = sorted(self.setOfLSToProcess)
+            topTargets = as_a_list[0:self.maximumFilesPerJob]
+            self.setOfExpressLS = set(topTargets)
+        else:
+            self.setOfExpressLS = self.setOfLSToProcess
 
-        self.setOfExpressLS = self.setOfLSToProcess
+        # self.setOfExpressLS = self.setOfLSToProcess
         # Extract all LS numbers (as integers)
         str_paths = {"root://eoscms.cern.ch/" + str(p) for p in self.setOfExpressLS}
 
@@ -537,7 +537,6 @@ class NGTLoopStep2:
         logging.info(ls_numbers)
 
         # ls_numbers = [int(re.search(r"ls(\d{4})", path).group(1)) for path in str_paths]
-
         # Compute min and max, then format back
         min_ls = min(ls_numbers, default=None)
         max_ls = max(ls_numbers, default=None)
@@ -766,6 +765,8 @@ rm {self.tempScriptName}
         self.setOfExpressLS = set()
         self.setOfLSProcessed = set()
         self.setOfExpectedOutputs = set()
+
+        logging.info(f"STARTUP CHECK: Script inherited KRB5CCNAME = {os.environ.get('KRB5CCNAME', 'NOT SET')}")
 
         print(f"We are processing {self.calibration_name}.")
         self.ResetTheMachine()


### PR DESCRIPTION
Adds improved logging for debugging to check whether inheritance of `KRB5CCNAME` environment variable worked correctly and puts a maximum on how many files per job step 2 can launch (for now step to 5) s.t. we dont have oversized jobs.


Goes towards addressing https://github.com/cms-ngt-hlt/NGTCalibrationLoop/issues/23 

This was tested in production and the changes works as intended.

With this in place, we can test with SST bad components mask again, however setting the max file list to 1 instead of 5 in hopes it eats up less disk  @mmusich 


full credits to @trtomei since i just uncommented and formatted what he had already put in there