### PR TITLE
Adjust latch time and add new waiting conditions fixing #24 

### DIFF
--- a/NGTLoopStep2.py
+++ b/NGTLoopStep2.py
@@ -230,7 +230,7 @@ class NGTLoopStep2:
         # New implementation: we just ask for
         # protons, collisions2025
         # has more than 50LS
-        # started less than 8 hours ago
+        # started less than 7.5 hours ago
         # directory does not already exist
         # Of those, pick the one with lowest run number.
         # ---
@@ -274,8 +274,8 @@ class NGTLoopStep2:
             )
             runDirMissing = not Path(f"/data/ngt/{self.calibration_name}/run{run_number}").exists()
             # We want a run that
-            # 1. (is not running AND is long enough AND has started less than 8 hours ago)
-            # OR (2. is still running AND has started less than 8 hours ago)
+            # 1. (is not running AND is long enough AND has started less than 7.5 hours ago)
+            # OR (2. is still running AND has started less than 7.5 hours ago)
             if is_running and isRecentRun and runDirMissing:  # Found a live run!
                 logging.info(
                     f"Found running run {run_number},"
@@ -689,7 +689,8 @@ rm {self.tempScriptName}
         self.startTime = 0
         self.minimumLS = 1  # these variable names are a bit misleading as they are not
         self.maximumFilesPerJob = 5
-        self.maxLatchTimeInHours = 8  # due to 8 hours of buffering
+        # due to 8 hours of buffering and the 2x 15 min grace periods of step 3 and step 4
+        self.maxLatchTimeInHours = 7.5
         self.runStartTime = None
         self.waitingLS = False
         self.enoughLS = False
@@ -747,7 +748,7 @@ rm {self.tempScriptName}
         self.minimumLS = 1
         self.minLSToProcess = 1
         self.maximumFilesPerJob = 5
-        self.maxLatchTimeInHours = 8
+        self.maxLatchTimeInHours = 7.5
         self.runStartTime = None
         self.waitingLS = False
         self.enoughLS = False

--- a/NGTLoopStep3.py
+++ b/NGTLoopStep3.py
@@ -126,10 +126,79 @@ class NGTLoopStep3:
         if runEndedFile.exists():
             print("The run is complete!")
             logging.info("The run is complete!")
+            if self.runEndTime is None:
+                self.runEndTime = datetime.now(timezone.utc)
         else:
             print("Not yet...")
             logging.info("Not yet...")
         return not runEndedFile.exists()
+
+    def AllExpectedFilesArrived(self):
+        """Return True if all files listed in expectedOutputs.log have been observed."""
+        expected_log = Path(self.workingDir) / "expectedOutputs.log"
+        if not expected_log.exists():
+            print("expectedOutputs.log not found yet.")
+            logging.info("expectedOutputs.log not found yet.")
+            return False
+
+        with open(expected_log, "r", encoding="utf-8") as f:
+            expected_files = {line.strip() for line in f if line.strip()}
+
+        observed_filenames = {os.path.basename(str(p)) for p in self.setOfFilesObserved}
+
+        all_arrived = expected_files.issubset(observed_filenames)
+        if all_arrived:
+            print("All expected files have arrived.")
+            logging.info("All expected files have arrived.")
+        else:
+            missing = expected_files - observed_filenames
+            print(f"Still waiting for {len(missing)} files: {missing}")
+            logging.info(f"Still waiting for {len(missing)} files: {missing}")
+        return all_arrived
+
+    def RunEndGracePeriodExpired(self):
+        """Return True if the grace period after the run ended has expired."""
+        if self.runEndTime is None:
+            return False
+        now_utc = datetime.now(timezone.utc)
+        diff = now_utc - self.runEndTime
+        expired = diff.total_seconds() >= self.gracePeriodInSeconds
+        if expired:
+            print("Grace period expired.")
+            logging.info("Grace period expired.")
+        else:
+            print(
+                f"Still in grace period: {diff.total_seconds():.1f}s / {self.gracePeriodInSeconds}s"
+            )
+            logging.info(
+                f"Still in grace period: {diff.total_seconds():.1f}s / {self.gracePeriodInSeconds}s"
+            )
+        return expired
+
+    def ShouldContinueWaiting(self):
+        """Consolidated logic to decide if we should remain in WaitingForStep2Files."""
+        # 1. The run is still active OR the file checklist is incomplete.
+        # 2. AND the 15-minute grace period has not yet expired.
+        # 3. AND the overall timeout has not been reached.
+
+        run_is_active = self.RunIsNotComplete()
+        files_incomplete = not self.AllExpectedFilesArrived()
+        grace_period_expired = self.RunEndGracePeriodExpired()
+        still_have_time = self.StillHaveTime()
+
+        should_wait = (
+            (run_is_active or files_incomplete)
+            and (not grace_period_expired)
+            and still_have_time
+        )
+
+        if should_wait:
+            print("ShouldContinueWaiting: True")
+            logging.info("ShouldContinueWaiting: True")
+        else:
+            print("ShouldContinueWaiting: False")
+            logging.info("ShouldContinueWaiting: False")
+        return should_wait
 
     def StillHaveTime(self):
         """Return True if the elapsed time since the run started is within the
@@ -407,7 +476,9 @@ rm ALCAOUTPUT.sh
         logging.info("Machine reset!")
         self.runNumber = 0
         self.startTime = 0
-        self.timeoutInSeconds = 9 * 60 * 60  # 8 hours
+        self.timeoutInSeconds = 7.75 * 60 * 60  # 7.75 hours
+        self.gracePeriodInSeconds = 15 * 60  # 15 minutes
+        self.runEndTime = None
         self.minimumFiles = 1
         self.maximumFiles = 5
         self.requestMinimumFiles = True
@@ -535,18 +606,16 @@ rm ALCAOUTPUT.sh
             conditions=["ThereAreFilesWaiting", "ThereAreEnoughFiles"],
         )
 
-        # If we don't have enough Files, but we are still running,
-        # more Files will come. We go to WaitingForStep2Files,
-        # but only if we still have time!
+        # If we don't have enough Files, we go to WaitingForStep2Files if logic permits
         self.machine.add_transition(
             trigger="ContinueAfterCheckFiles",
             source="CheckingFilesForProcess",
             dest="WaitingForStep2Files",
-            conditions=["RunIsNotComplete", "StillHaveTime"],
+            conditions="ShouldContinueWaiting",
         )
 
-        # If we don't have enough Files, and we are not still running,
-        # no more Files will come. We go to PreparingFinalFiles
+        # If we don't have enough Files, and we should NOT continue waiting,
+        # go to PreparingFinalFiles
         self.machine.add_transition(
             trigger="ContinueAfterCheckFiles",
             source="CheckingFilesForProcess",

--- a/NGTLoopStep3.py
+++ b/NGTLoopStep3.py
@@ -186,11 +186,7 @@ class NGTLoopStep3:
         grace_period_expired = self.RunEndGracePeriodExpired()
         still_have_time = self.StillHaveTime()
 
-        should_wait = (
-            (run_is_active or files_incomplete)
-            and (not grace_period_expired)
-            and still_have_time
-        )
+        should_wait = (run_is_active or files_incomplete) and not grace_period_expired and still_have_time
 
         if should_wait:
             print("ShouldContinueWaiting: True")

--- a/NGTLoopStep4.py
+++ b/NGTLoopStep4.py
@@ -129,10 +129,31 @@ class NGTLoopStep4:
         if runEndedFile.exists():
             print("The run is complete!")
             logging.info("The run is complete!")
+            if self.runEndTime is None:
+                self.runEndTime = datetime.now(timezone.utc)
         else:
             print("Not yet...")
             logging.info("Not yet...")
         return not runEndedFile.exists()
+
+    def InGracePeriod(self):
+        """Return True if we are within the grace period after the run ended."""
+        if self.runEndTime is None:
+            return False
+        now_utc = datetime.now(timezone.utc)
+        diff = now_utc - self.runEndTime
+        in_grace = diff.total_seconds() < self.gracePeriodInSeconds
+        if in_grace:
+            print(
+                f"Still in grace period: {diff.total_seconds():.1f}s / {self.gracePeriodInSeconds}s"
+            )
+            logging.info(
+                f"Still in grace period: {diff.total_seconds():.1f}s / {self.gracePeriodInSeconds}s"
+            )
+        else:
+            print("Grace period expired.")
+            logging.info("Grace period expired.")
+        return in_grace
 
     def StillHaveTime(self):
         """Return True if the elapsed time since the run started is within the
@@ -417,7 +438,9 @@ uploadConditions.py {final_db_name}
         logging.info("Machine reset!")
         self.runNumber = 0
         self.startTime = 0
-        self.timeoutInSeconds = 8 * 60 * 60  # 8 hours
+        self.timeoutInSeconds = 8.0 * 60 * 60  # 8.0 hours
+        self.gracePeriodInSeconds = 30 * 60  # 30 minutes
+        self.runEndTime = None
         self.minimumFiles = 1
         self.waitingFiles = False
         self.enoughFiles = False
@@ -553,7 +576,16 @@ uploadConditions.py {final_db_name}
             conditions=["RunIsNotComplete", "StillHaveTime"],
         )
 
-        # If we don't have enough Files, and we are not still running,
+        # If the run IS complete (runEnd.log exists), we might still want to wait
+        # for more files to appear (e.g. from Step 3), within a grace period.
+        self.machine.add_transition(
+            trigger="ContinueAfterCheckFiles",
+            source="CheckingFilesForProcess",
+            dest="WaitingForFiles",
+            conditions="InGracePeriod",
+        )
+
+        # If we don't have enough Files, and we are not still running (and grace period expired),
         # no more Files will come. We go to PreparingFinalFiles
         self.machine.add_transition(
             trigger="ContinueAfterCheckFiles",


### PR DESCRIPTION
Fixes race conditions in https://github.com/cms-ngt-hlt/NGTCalibrationLoop/issues/24



This PR fixes the race conditions issue experienced and explained in #24 that mainly affected short runs where only one job was launched via step 2. The concrete problem at hand is that step 2 signals to step 3 once step 2 has launched all the jobs it has to and is done with a given run, it will tell step 3 „move on“, this was implemented s.t. step 3 is not stuck forever on a run and knows where to move on. this, however, step 3 seeing the signal from step 2 saying „move on“, but not looking again whether new jobs had been launched right in that minute (which is where the race condition appears). step 3 moves on. we fix this issue by:

1  book-keeping in step3 (`AllExpectedFilesArrived`): checks whether all the files coming out of the jobs created by step 2 have already been found (in a sense that they are done being processed) and processed by step 3 (processed in a sense that we have launched jobs with it) and only „exiting the loop“ once  

2 add grace period to step 3: an issue by introducing `AllExpectedFilesArrived`, is that in case somewhere along the line, the list of expected files is „corrupted“ for whatever reason, it will be stuck forever waiting for files that never come —> grace period of 15 minutes added to step 3 such that in case 15 minutes are over, it *moves on*. this gives the step 2 jobs time to finish processing. for this, a new condition is introduced, namely `RunEndGracePeriodExpired` and `ShouldContinueWaiting` to consolidate the new logic. ShouldContinueWaiting essentially checks if any of the following is true:
- the run is still active OR the checklist is incomplete
- grace period is not over (in case step 2 has signalled to step 3 that it should move on)
- „timeout“ period has not been reached (i.e. are we still within the 8 hours time window)

If any of this still returns true, we will continue waiting. For this to work, the conditions for transitions destination `WaitingForStep2Files was changed to be `ShouldContinueWaiting` to be able to check for the ORs of conditions being met. 

3 add grace period condition to step 4: step 4 also listens to step 2 signal to „stop looking at this run“, so a grace period also had to be added here! since step 4 is either way greedy, it is enough to just add an „inGracePeriod“ condition

4 with the addition of grace periods, the loop is not in time anymore, so we had to change the „check out“ times of step 2 to be 7.5 hours and step 3 to be 7.75 hours to accomodate for the new grace periods.

This PR has not been tested yet and I am incredibly scared of crashing a running system.
