### PR TITLE
Add high-purity BeamSpot calibration

### DIFF
--- a/NGTLoopStep2.py
+++ b/NGTLoopStep2.py
@@ -34,9 +34,9 @@ parser.add_argument(
     "-c",
     "--calibration",
     type=str,
-    help="Calibration workflow to process: e.g. SiStripBad or EcalPedestals.",
+    help="Calibration workflow to process: SiStripBad, EcalPedestals or BeamSpot",
     required=True,
-    choices=["SiStripBad", "EcalPedestals"],
+    choices=["SiStripBad", "EcalPedestals", "BeamSpot"],
 )
 args = parser.parse_args()
 

--- a/NGTLoopStep3.py
+++ b/NGTLoopStep3.py
@@ -28,9 +28,9 @@ parser.add_argument(
     "-c",
     "--calibration",
     type=str,
-    help="Calibration workflow to process: e.g. SiStripBad or EcalPedestals.",
+    help="Calibration workflow to process: SiStripBad, EcalPedestals or BeamSpot",
     required=True,
-    choices=["SiStripBad", "EcalPedestals"],
+    choices=["SiStripBad", "EcalPedestals", "BeamSpot"],
 )
 args = parser.parse_args()
 

--- a/NGTLoopStep4.py
+++ b/NGTLoopStep4.py
@@ -276,7 +276,7 @@ class NGTLoopStep4:
             "destinationDatabase": conf_upload["destinationDatabase"],
             "destinationTags": conf_upload["destinationTags"],
             "inputTag": conf_upload["inputTag"],
-            "since": self.runNumber,
+            "since": null,
             "userText": conf_upload["userText"],
         }
         metadataFile = alcaJobDir / Path(conf_step4["metadata_filename"])

--- a/NGTLoopStep4.py
+++ b/NGTLoopStep4.py
@@ -32,9 +32,9 @@ parser.add_argument(
     "-c",
     "--calibration",
     type=str,
-    help="Calibration workflow to process: e.g. SiStripBad or EcalPedestals.",
+    help="Calibration workflow to process: SiStripBad, EcalPedestals or BeamSpot",
     required=True,
-    choices=["SiStripBad", "EcalPedestals"],
+    choices=["SiStripBad", "EcalPedestals", "BeamSpot"],
 )
 args = parser.parse_args()
 

--- a/NGTLoopStep4.py
+++ b/NGTLoopStep4.py
@@ -271,12 +271,14 @@ class NGTLoopStep4:
         conf_driver = conf_step4["cms_driver"]
         conf_upload = conf_step4["upload_metadata"]
 
+        since = None if "BeamSpot" in self.calibration_name else self.runNumber
+
         # Write the metadata for the upload
         metadata = {
             "destinationDatabase": conf_upload["destinationDatabase"],
             "destinationTags": conf_upload["destinationTags"],
             "inputTag": conf_upload["inputTag"],
-            "since": null,
+            "since": since,
             "userText": conf_upload["userText"],
         }
         metadataFile = alcaJobDir / Path(conf_step4["metadata_filename"])

--- a/calibrationYAML/BeamSpot.yaml
+++ b/calibrationYAML/BeamSpot.yaml
@@ -1,0 +1,55 @@
+calibration_name: "BeamSpot"
+
+file_in_path: "/eos/cms/tier0/store/express/Run2026D/ExpressPhysics/FEVT/Express-v1/000/"
+
+# --- STEP 2 CONFIG ---
+step_2_config:
+  filltype : "PROTONS"
+  l1hltmode: "collisions2026"
+  minLsToProcess : 1
+  step: "RAW2DIGI,RECO,ALCAPRODUCER:TkAlMinBias+PromptCalibProdBeamSpotHP"
+  procModifier: "trackingIters01"
+  scenario: "pp"
+  datatier: "ALCARECO"
+  eventcontent: "ALCARECO"
+  process: "RERECO"
+  era: "Run3"
+  nThreads: 8
+  nStreams: 8
+  output_filename_affix: "_beamSpotStep2"
+  
+# --- STEP 3 CONFIG ---
+step_3_config:
+  step_2_root_suffix: "beamSpotStep2.root"
+  step_2_witness_suffix: "beamSpotStep2_job.txt"
+  cms_driver:
+    step: "ALCAOUTPUT:TkAlMinBias,ALCA:PromptCalibProdBeamSpotHP"
+    python_filename_affix: "_beamSpotALCAOUTPUT"
+    triggerResultsProcess: "RECO"
+    step_3_witness_suffix: "beamSpotStep3_job.txt"
+    cleanup_command: "" # todo clean up command here
+
+# --- STEP 4 CONFIG (ALCAHARVEST) ---
+step_4_config:
+  step_3_witness_suffix: "beamSpotStep3_job.txt"
+  step_3_root_filename: "PromptCalibProdBeamSpotHP.root" 
+
+  # CMSSW environment and paths
+  cmssw_base_path: "/nfshome0/sakura/"
+  cms_driver:
+    step: "ALCAHARVEST:BeamSpotHPByLumi" 
+    scenario: "pp"
+    python_filename_affix: "_beamSpotHARVESTING"
+    python_config_mods:
+      - 'process.PoolDBOutputService.toPut[0].tag = cms.string("BeamSpot_NGTDemonstrator")'
+  
+  upload_metadata:
+    destinationDatabase: "oracle://cms_orcon_prod/CMS_CONDITIONS"
+    destinationTags:
+      BeamSpot_NGTDemonstrator: {} # Key is the final tag name
+    inputTag: "BeamSpot_NGTDemonstrator"
+    userText: "Periodical fill-up BeamSpot upload for NGT Demonstrator"
+  
+  # Final file names
+  metadata_filename: "NGTCalibBeamSpot.txt"
+  final_db_name: "NGTCalibBeamSpot.db"


### PR DESCRIPTION
Adds a high-purity LS-based BeamSpot workflow with AlCaRECO producers: `TkAlMinBias` and [`PromptCalibProdBeamSpotHP`](https://github.com/cms-sw/cmssw/blob/master/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdBeamSpotHP_cff.py), which use a simplified tracking with only the first two iterations (`trackingIters01`) via a process modifier (`procModifier`). The AlCa harvesting is  `BeamSpotHPByLumi`. The new tag to write to is `BeamSpot_NGTDemonstrator`.