### PR TITLE
tmux launch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ EOS RAW Files
     ↓
 Automatic Database Upload
 ```
+## tmux quick start
+To understand exactly what goes into each step, please refer at the `Setting up and running` section. This section assumes, you just want to relaunch scripts after new developments that you want to run on and no tmux sessions running anymore (`tmux kill-server`). Make sure you are in the correct directory and that `cmsenv` is set. To launch all three tmux sessions at the same time, it just needs the input argument of which calibration one wants to launch, so simply:
+```
+./tmux_launch.sh -c SiStripBad # or -c Beamspot or -c EcalPedestals
+```
+This will launch the tmux sessions and make the respective script run inside of it. 
+
+
 
 ## Setting up and running
 

--- a/tmux_launch.sh
+++ b/tmux_launch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+while getopts "c:" opt; do
+  case $opt in
+    c) CALIBRATION="$OPTARG" ;;
+    *) echo "Usage: $0 -c EcalPedestals|SiStripBad|BeamSpot"; exit 1 ;;
+  esac
+done
+
+if [[ "$CALIBRATION" != "EcalPedestals" && "$CALIBRATION" != "SiStripBad" && "$CALIBRATION" != "BeamSpot" ]]; then
+  echo "Error: calibration -c must be EcalPedestals, SiStripBad, or BeamSpot"
+  exit 1
+fi
+
+tmux new-session -d -s CalibrationLoop2_$CALIBRATION "python3 NGTLoopStep2.py -c $CALIBRATION; bash"
+tmux new-session -d -s CalibrationLoop3_$CALIBRATION "python3 NGTLoopStep3.py -c $CALIBRATION; bash"
+tmux new-session -d -s CalibrationLoop4_$CALIBRATION "python3 NGTLoopStep4.py -c $CALIBRATION; bash"
+
+echo "Launched CalibrationLoop2/3/4 with -c $CALIBRATION"


### PR DESCRIPTION
Tiny quality of life update, as then we dont need to start each single tmux session by hand but can just do one command in total :)

When running:
```
./tmux_launch.sh -c SiStripBad
```
it will automatically launch the tmux sessions as well as including the python command that should be launched within the given tmux session. No further actions required. It will fail if there is no input that specifies the calibration type and only accepts `SiStripBad`, `EcalPedestals` or `BeamSpot` as an option. 

This is tested on the ngtcalfu machines and looks like it works as expected.